### PR TITLE
Include typings in dist files list

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   "files": [
     "LICENSE.md",
     "README.md",
-    "dist/blowfish.js"
+    "dist/blowfish.js",
+    "egoroof-blowfish.d.ts"
   ],
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
Because otherwise typings are not available when doing ```npm install egoroof-blowfish --save```:
![image](https://user-images.githubusercontent.com/5520406/71558940-11f9cf80-2a61-11ea-8f07-2ccf27b48344.png)

Fixes #14